### PR TITLE
Add customerCode and productCode to order records

### DIFF
--- a/src/main/java/codesumn/sboot/order/dispatcher/application/dtos/records/order/OrderItemRecordDto.java
+++ b/src/main/java/codesumn/sboot/order/dispatcher/application/dtos/records/order/OrderItemRecordDto.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 
 public record OrderItemRecordDto(
         @NotBlank UUID id,
+        @NotBlank String productCode,
         @NotBlank String productName,
         @NotNull @Min(1) Integer quantity,
         @NotNull @Min(0) BigDecimal unitPrice

--- a/src/main/java/codesumn/sboot/order/dispatcher/application/dtos/records/order/OrderRecordDto.java
+++ b/src/main/java/codesumn/sboot/order/dispatcher/application/dtos/records/order/OrderRecordDto.java
@@ -11,6 +11,7 @@ import java.util.UUID;
 
 public record OrderRecordDto(
         @NotNull UUID id,
+        @NotBlank String customerCode,
         @NotBlank String customerName,
         @NotNull OrderStatusEnum orderStatus,
         @Min(0) BigDecimal totalPrice,

--- a/src/main/java/codesumn/sboot/order/dispatcher/application/services/OrderProcessorService.java
+++ b/src/main/java/codesumn/sboot/order/dispatcher/application/services/OrderProcessorService.java
@@ -27,6 +27,7 @@ public class OrderProcessorService implements OrderProcessorPort {
 
         OrderRecordDto orderProcessed = new OrderRecordDto(
                 order.id(),
+                order.customerCode(),
                 order.customerName(),
                 OrderStatusEnum.PROCESSED,
                 totalPrice,


### PR DESCRIPTION
- Add `customerCode` to `OrderRecordDto` for better identification of customers.
- Include `productCode` in `OrderItemRecordDto` to enhance product tracking.
- Update `OrderProcessorService` to populate `customerCode` when processing orders.