### PR TITLE
Add message compression and update RabbitMQ config

### DIFF
--- a/src/main/java/codesumn/sboot/order/dispatcher/application/config/RabbitMQConfig.java
+++ b/src/main/java/codesumn/sboot/order/dispatcher/application/config/RabbitMQConfig.java
@@ -1,5 +1,7 @@
 package codesumn.sboot.order.dispatcher.application.config;
 
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageDeliveryMode;
 import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
@@ -9,6 +11,10 @@ import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.zip.GZIPOutputStream;
+
 @Configuration
 public class RabbitMQConfig {
 
@@ -17,6 +23,21 @@ public class RabbitMQConfig {
         RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
         rabbitTemplate.setMessageConverter(jackson2JsonMessageConverter());
         rabbitTemplate.setMandatory(true);
+
+        rabbitTemplate.setConfirmCallback((correlationData, ack, cause) -> {
+            if (!ack) {
+                System.err.println("Erro no envio da mensagem: " + cause);
+            }
+        });
+
+        rabbitTemplate.setBeforePublishPostProcessors(message -> {
+            byte[] compressedBody = compress(message.getBody());
+            message.getMessageProperties().setContentEncoding("gzip");
+            message.getMessageProperties().setContentLength(compressedBody.length);
+            message.getMessageProperties().setDeliveryMode(MessageDeliveryMode.PERSISTENT);
+            return new Message(compressedBody, message.getMessageProperties());
+        });
+
         return rabbitTemplate;
     }
 
@@ -32,9 +53,22 @@ public class RabbitMQConfig {
         SimpleRabbitListenerContainerFactory factory = new SimpleRabbitListenerContainerFactory();
         factory.setConnectionFactory(connectionFactory);
         factory.setMessageConverter(jackson2JsonMessageConverter());
-        factory.setConcurrentConsumers(1);
-        factory.setMaxConcurrentConsumers(1);
-        factory.setPrefetchCount(1);
+
+        factory.setConcurrentConsumers(3);
+        factory.setMaxConcurrentConsumers(5);
+        factory.setPrefetchCount(5);
+
         return factory;
+    }
+
+    private byte[] compress(byte[] data) {
+        try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
+             GZIPOutputStream gzip = new GZIPOutputStream(bos)) {
+            gzip.write(data);
+            gzip.close();
+            return bos.toByteArray();
+        } catch (IOException e) {
+            throw new RuntimeException("Erro ao comprimir mensagem", e);
+        }
     }
 }


### PR DESCRIPTION
- Implement GZIP compression for message bodies in `RabbitTemplate`.
- Set `Content-Encoding` to `gzip`, adjust `Content-Length`, and enforce persistence via `PERSISTENT` delivery mode.
- Introduce a callback to handle failed message delivery.
- Adjust `SimpleRabbitListenerContainerFactory` settings: increase concurrency to 3 and max concurrency to 5, with a prefetch count of 5.
- Add a private utility method `compress` for handling message compression.