### PR TITLE
Simplify RabbitMQ message handling with compression

### DIFF
--- a/src/main/java/codesumn/sboot/order/dispatcher/application/config/RabbitMQConfig.java
+++ b/src/main/java/codesumn/sboot/order/dispatcher/application/config/RabbitMQConfig.java
@@ -1,39 +1,51 @@
 package codesumn.sboot.order.dispatcher.application.config;
 
-import codesumn.sboot.order.dispatcher.application.dtos.records.order.OrderRecordDto;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageDeliveryMode;
 import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.rabbit.listener.RabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
-import org.springframework.amqp.support.converter.DefaultJackson2JavaTypeMapper;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import java.util.Collections;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
 
 @Configuration
 public class RabbitMQConfig {
-
-    @Bean
-    public Jackson2JsonMessageConverter jackson2JsonMessageConverter() {
-        DefaultJackson2JavaTypeMapper typeMapper = new DefaultJackson2JavaTypeMapper();
-        typeMapper.setIdClassMapping(Collections.singletonMap("OrderRecordDto", OrderRecordDto.class));
-        typeMapper.setTrustedPackages("*"); // Permite qualquer pacote
-
-        Jackson2JsonMessageConverter converter = new Jackson2JsonMessageConverter(new ObjectMapper());
-        converter.setJavaTypeMapper(typeMapper);
-        return converter;
-    }
 
     @Bean
     public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory) {
         RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
         rabbitTemplate.setMessageConverter(jackson2JsonMessageConverter());
         rabbitTemplate.setMandatory(true);
+
+        rabbitTemplate.setConfirmCallback((correlationData, ack, cause) -> {
+            if (!ack) {
+                System.err.println("Erro no envio da mensagem: " + cause);
+            }
+        });
+
+        rabbitTemplate.setBeforePublishPostProcessors(message -> {
+            byte[] compressedBody = compress(message.getBody());
+            message.getMessageProperties().setContentEncoding("gzip");
+            message.getMessageProperties().setContentLength(compressedBody.length);
+            message.getMessageProperties().setDeliveryMode(MessageDeliveryMode.PERSISTENT);
+            return new Message(compressedBody, message.getMessageProperties());
+        });
+
         return rabbitTemplate;
+    }
+
+    @Bean
+    public Jackson2JsonMessageConverter jackson2JsonMessageConverter() {
+        return new Jackson2JsonMessageConverter();
     }
 
     @Bean
@@ -43,9 +55,45 @@ public class RabbitMQConfig {
         SimpleRabbitListenerContainerFactory factory = new SimpleRabbitListenerContainerFactory();
         factory.setConnectionFactory(connectionFactory);
         factory.setMessageConverter(jackson2JsonMessageConverter());
+
+        factory.setAfterReceivePostProcessors(message -> {
+            if ("gzip".equalsIgnoreCase(message.getMessageProperties().getContentEncoding())) {
+                byte[] decompressedBody = decompress(message.getBody());
+                return new Message(decompressedBody, message.getMessageProperties());
+            }
+            return message;
+        });
+
         factory.setConcurrentConsumers(1);
         factory.setMaxConcurrentConsumers(1);
         factory.setPrefetchCount(1);
+
         return factory;
+    }
+
+    private static byte[] compress(byte[] data) {
+        try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
+             GZIPOutputStream gzip = new GZIPOutputStream(bos)) {
+            gzip.write(data);
+            gzip.close();
+            return bos.toByteArray();
+        } catch (IOException e) {
+            throw new RuntimeException("Erro ao comprimir mensagem", e);
+        }
+    }
+
+    private static byte[] decompress(byte[] compressedData) {
+        try (ByteArrayInputStream bis = new ByteArrayInputStream(compressedData);
+             GZIPInputStream gzip = new GZIPInputStream(bis);
+             ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
+            byte[] buffer = new byte[1024];
+            int len;
+            while ((len = gzip.read(buffer)) != -1) {
+                bos.write(buffer, 0, len);
+            }
+            return bos.toByteArray();
+        } catch (IOException e) {
+            throw new RuntimeException("Erro ao descomprimir mensagem", e);
+        }
     }
 }

--- a/src/main/java/codesumn/sboot/order/dispatcher/domain/inbound/OrderResponseMessagingPort.java
+++ b/src/main/java/codesumn/sboot/order/dispatcher/domain/inbound/OrderResponseMessagingPort.java
@@ -1,12 +1,7 @@
 package codesumn.sboot.order.dispatcher.domain.inbound;
 
-import com.rabbitmq.client.Channel;
-import org.springframework.amqp.core.Message;
-import org.springframework.amqp.rabbit.annotation.RabbitListener;
-import org.springframework.amqp.support.AmqpHeaders;
-import org.springframework.messaging.handler.annotation.Header;
+import codesumn.sboot.order.dispatcher.application.dtos.records.order.OrderRecordDto;
 
 public interface OrderResponseMessagingPort {
-    @RabbitListener(queues = "${spring.rabbitmq.order.queue}", ackMode = "MANUAL")
-    void consumeOrderResponse(Message message, @Header(AmqpHeaders.DELIVERY_TAG) long deliveryTag, Channel channel);
+    void consumeOrderResponse(OrderRecordDto order);
 }

--- a/src/main/java/codesumn/sboot/order/dispatcher/infrastructure/adapters/messaging/OrderResponseMessagingAdapter.java
+++ b/src/main/java/codesumn/sboot/order/dispatcher/infrastructure/adapters/messaging/OrderResponseMessagingAdapter.java
@@ -3,62 +3,22 @@ package codesumn.sboot.order.dispatcher.infrastructure.adapters.messaging;
 import codesumn.sboot.order.dispatcher.application.dtos.records.order.OrderRecordDto;
 import codesumn.sboot.order.dispatcher.domain.inbound.OrderProcessorPort;
 import codesumn.sboot.order.dispatcher.domain.inbound.OrderResponseMessagingPort;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.rabbitmq.client.Channel;
-import org.springframework.amqp.core.Message;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
-import org.springframework.amqp.support.AmqpHeaders;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.stereotype.Component;
-
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.util.zip.GZIPInputStream;
 
 @Component
 public class OrderResponseMessagingAdapter implements OrderResponseMessagingPort {
 
     private final OrderProcessorPort orderProcessorPort;
-    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Autowired
     public OrderResponseMessagingAdapter(OrderProcessorPort orderProcessorPort) {
         this.orderProcessorPort = orderProcessorPort;
     }
 
-    @RabbitListener(queues = "${spring.rabbitmq.order.queue}", ackMode = "MANUAL")
-    @Override
-    public void consumeOrderResponse(
-            Message message,
-            @Header(AmqpHeaders.DELIVERY_TAG) long deliveryTag,
-            Channel channel
-    ) {
-        try {
-            byte[] decompressedBody = decompress(message.getBody());
-
-            OrderRecordDto order = objectMapper.readValue(decompressedBody, OrderRecordDto.class);
-
-            orderProcessorPort.processOrder(order);
-
-            channel.basicAck(deliveryTag, false);
-        } catch (Exception e) {
-            System.err.println("Erro ao processar pedido: " + e.getMessage());
-
-            try {
-                channel.basicNack(deliveryTag, false, true);
-            } catch (IOException ioException) {
-                System.err.println("Erro ao reencaminhar mensagem: " + ioException.getMessage());
-            }
-        }
-    }
-
-    private byte[] decompress(byte[] compressedData) {
-        try (ByteArrayInputStream bis = new ByteArrayInputStream(compressedData);
-             GZIPInputStream gzipInputStream = new GZIPInputStream(bis)) {
-            return gzipInputStream.readAllBytes();
-        } catch (IOException e) {
-            throw new RuntimeException("Erro ao descompactar mensagem", e);
-        }
+    @RabbitListener(queues = "${spring.rabbitmq.order.queue}")
+    public void consumeOrderResponse(OrderRecordDto order) {
+        orderProcessorPort.processOrder(order);
     }
 }


### PR DESCRIPTION
- Replaced manual message acknowledgment and decompression logic with built-in RabbitMQ configurators to simplify message handling.
- Refactored `OrderResponseMessagingAdapter` to directly handle `OrderRecordDto` instead of raw `Message`.
- Added GZIP compression and decompression handlers in `RabbitMQConfig` for both publishing and consuming messages to optimize message size.
- Removed redundant dependencies and logic around `Channel`, `Message`, and explicit decompression in the messaging adapter.