### PR TITLE
Switch to byte array message handling in RabbitMQ

### DIFF
--- a/src/main/java/codesumn/sboot/order/dispatcher/application/config/RabbitMQConfig.java
+++ b/src/main/java/codesumn/sboot/order/dispatcher/application/config/RabbitMQConfig.java
@@ -1,21 +1,12 @@
 package codesumn.sboot.order.dispatcher.application.config;
 
-import org.springframework.amqp.core.Message;
-import org.springframework.amqp.core.MessageDeliveryMode;
 import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.rabbit.listener.RabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
-import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.util.zip.GZIPInputStream;
-import java.util.zip.GZIPOutputStream;
 
 @Configuration
 public class RabbitMQConfig {
@@ -23,7 +14,6 @@ public class RabbitMQConfig {
     @Bean
     public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory) {
         RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
-        rabbitTemplate.setMessageConverter(jackson2JsonMessageConverter());
         rabbitTemplate.setMandatory(true);
 
         rabbitTemplate.setConfirmCallback((correlationData, ack, cause) -> {
@@ -32,20 +22,7 @@ public class RabbitMQConfig {
             }
         });
 
-        rabbitTemplate.setBeforePublishPostProcessors(message -> {
-            byte[] compressedBody = compress(message.getBody());
-            message.getMessageProperties().setContentEncoding("gzip");
-            message.getMessageProperties().setContentLength(compressedBody.length);
-            message.getMessageProperties().setDeliveryMode(MessageDeliveryMode.PERSISTENT);
-            return new Message(compressedBody, message.getMessageProperties());
-        });
-
         return rabbitTemplate;
-    }
-
-    @Bean
-    public Jackson2JsonMessageConverter jackson2JsonMessageConverter() {
-        return new Jackson2JsonMessageConverter();
     }
 
     @Bean
@@ -54,46 +31,10 @@ public class RabbitMQConfig {
     ) {
         SimpleRabbitListenerContainerFactory factory = new SimpleRabbitListenerContainerFactory();
         factory.setConnectionFactory(connectionFactory);
-        factory.setMessageConverter(jackson2JsonMessageConverter());
-
-        factory.setAfterReceivePostProcessors(message -> {
-            if ("gzip".equalsIgnoreCase(message.getMessageProperties().getContentEncoding())) {
-                byte[] decompressedBody = decompress(message.getBody());
-                return new Message(decompressedBody, message.getMessageProperties());
-            }
-            return message;
-        });
-
         factory.setConcurrentConsumers(1);
         factory.setMaxConcurrentConsumers(1);
         factory.setPrefetchCount(1);
 
         return factory;
-    }
-
-    private static byte[] compress(byte[] data) {
-        try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
-             GZIPOutputStream gzip = new GZIPOutputStream(bos)) {
-            gzip.write(data);
-            gzip.close();
-            return bos.toByteArray();
-        } catch (IOException e) {
-            throw new RuntimeException("Erro ao comprimir mensagem", e);
-        }
-    }
-
-    private static byte[] decompress(byte[] compressedData) {
-        try (ByteArrayInputStream bis = new ByteArrayInputStream(compressedData);
-             GZIPInputStream gzip = new GZIPInputStream(bis);
-             ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
-            byte[] buffer = new byte[1024];
-            int len;
-            while ((len = gzip.read(buffer)) != -1) {
-                bos.write(buffer, 0, len);
-            }
-            return bos.toByteArray();
-        } catch (IOException e) {
-            throw new RuntimeException("Erro ao descomprimir mensagem", e);
-        }
     }
 }

--- a/src/main/java/codesumn/sboot/order/dispatcher/domain/inbound/OrderResponseMessagingPort.java
+++ b/src/main/java/codesumn/sboot/order/dispatcher/domain/inbound/OrderResponseMessagingPort.java
@@ -1,7 +1,5 @@
 package codesumn.sboot.order.dispatcher.domain.inbound;
 
-import codesumn.sboot.order.dispatcher.application.dtos.records.order.OrderRecordDto;
-
 public interface OrderResponseMessagingPort {
-    void consumeOrderResponse(OrderRecordDto order);
+    void consumeOrderResponse(byte[] message);
 }

--- a/src/main/java/codesumn/sboot/order/dispatcher/infrastructure/adapters/messaging/OrderMessagingAdapter.java
+++ b/src/main/java/codesumn/sboot/order/dispatcher/infrastructure/adapters/messaging/OrderMessagingAdapter.java
@@ -2,6 +2,8 @@ package codesumn.sboot.order.dispatcher.infrastructure.adapters.messaging;
 
 import codesumn.sboot.order.dispatcher.application.dtos.records.order.OrderRecordDto;
 import codesumn.sboot.order.dispatcher.domain.outbound.OrderMessagingPort;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.amqp.core.Message;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -12,19 +14,28 @@ public class OrderMessagingAdapter implements OrderMessagingPort {
     private final RabbitTemplate rabbitTemplate;
     private final String responseExchange;
     private final String responseRoutingKey;
+    private final ObjectMapper objectMapper;
 
     public OrderMessagingAdapter(
             RabbitTemplate rabbitTemplate,
             @Value("${spring.rabbitmq.processor.response.exchange}") String responseExchange,
-            @Value("${spring.rabbitmq.processor.response.routing.key}") String responseRoutingKey
+            @Value("${spring.rabbitmq.processor.response.routing.key}") String responseRoutingKey,
+            ObjectMapper objectMapper
     ) {
         this.rabbitTemplate = rabbitTemplate;
         this.responseExchange = responseExchange;
         this.responseRoutingKey = responseRoutingKey;
+        this.objectMapper = objectMapper;
     }
 
     @Override
     public void sendOrder(OrderRecordDto order) {
-        rabbitTemplate.convertAndSend(responseExchange, responseRoutingKey, order);
+        try {
+            byte[] messageBytes = objectMapper.writeValueAsBytes(order);
+            Message message = new Message(messageBytes);
+            rabbitTemplate.send(responseExchange, responseRoutingKey, message);
+        } catch (Exception e) {
+            throw new RuntimeException("Erro ao serializar mensagem para JSON", e);
+        }
     }
 }


### PR DESCRIPTION
- Updated `OrderResponseMessagingAdapter` to deserialize messages from byte arrays using `ObjectMapper`.
- Replaced `consumeOrderResponse` to handle raw byte arrays instead of `OrderRecordDto`.
- Refactored `OrderMessagingAdapter` to serialize `OrderRecordDto` into a byte array before sending.
- Removed custom compression/decompression logic from `RabbitMQConfig`.
- Eliminated the `OrderResponseMessagingPort` interface due to unused references.
- Simplified RabbitMQ configuration by removing unused message converters and processors.