### PR TITLE
Update Flyway version and adjust logging level

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,4 @@
-extra["flywayCoreVersion"] = "11.2.0"
+extra["flywayCoreVersion"] = "11.3.0"
 extra["springdocVersion"] = "2.8.4"
 
 plugins {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,6 +5,7 @@ spring.datasource.driver-class-name=org.postgresql.Driver
 spring.datasource.url=${POSTGRES_URL:jdbc:postgresql://localhost:5433/dispatch_db}
 spring.datasource.username=${POSTGRES_USER:dispatch_user}
 spring.datasource.password=${POSTGRES_PASSWORD:dispatch_pass}
+logging.level.org.hibernate.orm.connections.pooling=WARN
 
 # Data JPA
 spring.jpa.hibernate.ddl-auto=update


### PR DESCRIPTION
- Bump Flyway Core version from 11.2.0 to 11.3.0 in `build.gradle.kts` for the latest updates.
- Set Hibernate connection pooling logging level to WARN in `application.properties` to reduce log noise.