### PR TITLE
Remove unused interface and redundant enum method

### DIFF
--- a/src/main/java/codesumn/sboot/order/dispatcher/domain/inbound/OrderResponseMessagingPort.java
+++ b/src/main/java/codesumn/sboot/order/dispatcher/domain/inbound/OrderResponseMessagingPort.java
@@ -1,5 +1,0 @@
-package codesumn.sboot.order.dispatcher.domain.inbound;
-
-public interface OrderResponseMessagingPort {
-    void consumeOrderResponse(byte[] message);
-}

--- a/src/main/java/codesumn/sboot/order/dispatcher/shared/enums/OrderStatusEnum.java
+++ b/src/main/java/codesumn/sboot/order/dispatcher/shared/enums/OrderStatusEnum.java
@@ -14,12 +14,4 @@ public enum OrderStatusEnum {
 
     private final String value;
 
-    public static OrderStatusEnum fromValue(String value) {
-        for (OrderStatusEnum role : OrderStatusEnum.values()) {
-            if (role.value.equalsIgnoreCase(value)) {
-                return role;
-            }
-        }
-        return PROCESSING;
-    }
 }


### PR DESCRIPTION
- Delete `OrderResponseMessagingPort` interface as it is no longer used in the codebase.
- Remove `fromValue` method in `OrderStatusEnum`, which was unnecessary and simplified the enum implementation.