### PR TITLE
Simplify job name in Docker image workflow

### DIFF
--- a/.github/workflows/docker-image-ci.yml
+++ b/.github/workflows/docker-image-ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    name: Build and push Docker image to Docker Hub
+    name: Build and Push
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
- Rename `Build and push Docker image to Docker Hub` to `Build and Push` for brevity and improved readability.