### PR TITLE
Remove push event trigger from Docker Image CI workflow

### DIFF
--- a/.github/workflows/docker-image-ci.yml
+++ b/.github/workflows/docker-image-ci.yml
@@ -1,8 +1,6 @@
 name: Docker Image CI
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 


### PR DESCRIPTION
- Eliminate the `push` event trigger to restrict workflow execution to `pull_request` events only.
- Simplify the workflow configuration to reduce unnecessary triggers.