### PR TITLE
Trigger workflow on push to main instead of PR

### DIFF
--- a/.github/workflows/docker-image-ci.yml
+++ b/.github/workflows/docker-image-ci.yml
@@ -1,7 +1,7 @@
 name: Docker Image CI
 
 on:
-  pull_request:
+  push:
     branches: [ "main" ]
 
 jobs:


### PR DESCRIPTION
- Update GitHub Actions workflow to run on `push` to the `main` branch.
- Replace the previous `pull_request` trigger for better alignment with deployment processes.