### PR TITLE
Add support for multi-platform Docker image builds

### DIFF
--- a/.github/workflows/docker-image-ci.yml
+++ b/.github/workflows/docker-image-ci.yml
@@ -26,3 +26,4 @@ jobs:
           file: Dockerfile
           push: true
           tags: thoggs/sboot-order-dispatcher:latest
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
- Include `linux/amd64` and `linux/arm64` platforms in the workflow configuration.
- Enable building and pushing Docker images for multiple architectures.