### PR TITLE
Add QEMU and Buildx setup to Docker workflow

### DIFF
--- a/.github/workflows/docker-image-ci.yml
+++ b/.github/workflows/docker-image-ci.yml
@@ -13,6 +13,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
- Add `docker/setup-qemu-action@v3` for cross-platform emulation.
- Add `docker/setup-buildx-action@v3` to enable advanced Docker builds.
- Enhance Docker build workflow for better multi-platform support.