### PR TITLE
Add Jenkins pipeline for build automation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,15 @@
+pipeline {
+	agent any
+    stages {
+		stage('Checkout') {
+			steps {
+				git branch: 'main', url: 'https://github.com/thoggs/sboot-order-dispatcher.git'
+            }
+        }
+        stage('Build') {
+			steps {
+				sh 'docker build -t sboot-order-dispatcher:latest .'
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Introduce a Jenkinsfile to automate the build process.
- Include a 'Checkout' stage to fetch the code from the main branch.
- Add a 'Build' stage to create a Docker image with the latest tag.