### PR TITLE
Update Jenkinsfile with build options and triggers

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,15 @@
 pipeline {
 	agent any
 
+	options {
+		disableConcurrentBuilds()
+        buildDiscarder(logRotator(numToKeepStr: '4'))
+	}
+
+	triggers {
+		githubPush()
+    }
+
     environment {
 		DOCKER_IMAGE = 'thoggs/sboot-order-dispatcher:latest'
     }


### PR DESCRIPTION
- Add `disableConcurrentBuilds` to prevent overlapping builds.
- Configure `buildDiscarder` to retain the last 4 build logs.
- Introduce `githubPush` trigger to enable automatic builds on push events.