### PR TITLE
Add multi-arch Docker buildx support and caching

### DIFF
--- a/.github/workflows/docker-image-ci.yml
+++ b/.github/workflows/docker-image-ci.yml
@@ -33,3 +33,5 @@ jobs:
           push: true
           tags: thoggs/sboot-order-dispatcher:latest
           platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM oraclelinux:9 as builder
+FROM oraclelinux:9 AS builder
 
 RUN set -eux; \
     dnf install -y tar git wget unzip

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,12 +1,13 @@
 pipeline {
 	agent any
 
-	options {
+    options {
 		disableConcurrentBuilds()
         buildDiscarder(logRotator(numToKeepStr: '5'))
-	}
+        skipDefaultCheckout(true)
+    }
 
-	triggers {
+    triggers {
 		githubPush()
     }
 
@@ -21,36 +22,46 @@ pipeline {
             }
         }
 
-        stage('Build Docker Image') {
+        stage('Set up QEMU') {
 			steps {
-				sh 'docker build -t $DOCKER_IMAGE .'
+				sh 'docker run --rm --privileged multiarch/qemu-user-static --reset -p yes'
+            }
+        }
+
+        stage('Set up Docker Buildx') {
+			steps {
+				sh 'docker buildx create --use --name mybuilder || true'
+                sh 'docker buildx inspect --bootstrap'
             }
         }
 
         stage('Login to Docker Hub') {
 			steps {
 				withCredentials([
-					usernamePassword(
-						credentialsId: 'docker-hub-credentials',
+                    usernamePassword(
+                        credentialsId: 'docker-hub-credentials',
                         usernameVariable: 'DOCKER_USERNAME',
                         passwordVariable: 'DOCKER_PASSWORD'
-					)
-				]) {
+                    )
+                ]) {
 					sh 'echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin'
                 }
             }
         }
 
-        stage('Push to Docker Hub') {
+        stage('Build and Push Multi-Arch Docker Image') {
 			steps {
-				sh 'docker push $DOCKER_IMAGE'
+				sh '''
+                    docker buildx build --platform linux/amd64,linux/arm64 \
+                        -t $DOCKER_IMAGE \
+                        --push .
+                '''
             }
         }
 
         stage('Cleanup') {
 			steps {
-				sh 'docker rmi -f $DOCKER_IMAGE || true'
-                sh 'docker system prune -f --volumes || true'
+				sh 'docker system prune -f --volumes || true'
             }
         }
     }


### PR DESCRIPTION
- Configure QEMU and Docker buildx in Jenkins pipeline for multi-arch builds.
- Update "Build and Push Docker Image" stage to push multi-arch images.
- Enable Docker caching using GitHub Actions cache in the CI workflow.
- Improve Jenkins pipeline indentation and structure for readability.
- Standardize Dockerfile formatting (case-sensitive improvements).