### PR TITLE
Make Flyway properties configurable via env vars

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,8 +19,8 @@ spring.datasource.hikari.maximum-pool-size=80
 spring.datasource.hikari.minimum-idle=5
 
 # Flyway Migrations
-spring.flyway.locations=classpath:db/migration
-spring.flyway.baseline-on-migrate=true
+spring.flyway.locations=${FLYWAY_LOCATIONS:classpath:db/migration}
+spring.flyway.baseline-on-migrate=${FLYWAY_ON_MIGRATE:true}
 
 # RabbitMQ Configuration
 spring.rabbitmq.host=${RABBITMQ_HOST:localhost}


### PR DESCRIPTION
- updated spring.flyway.locations to use environment variable.
- made spring.flyway.baseline-on-migrate configurable via env vars.