### PR TITLE
Rename AWS ECR public login stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -106,7 +106,7 @@ pipeline {
             }
         }
 
-        stage('Login to AWS ECR Public') {
+        stage('Login to AWS ECR') {
 			steps {
 				container('aws-cli') {
 					withCredentials([


### PR DESCRIPTION
- updated stage name from 'Login to AWS ECR Public' to 'Login to AWS ECR'.