### PR TITLE
Update agent label in Jenkins pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -68,14 +68,13 @@
 
 pipeline {
 	agent {
-		label 'docker-builder'
+		label 'kub-suse-rancher-agent'
     }
 
     options {
 		buildDiscarder(logRotator(numToKeepStr: '5'))
         skipDefaultCheckout(true)
         disableConcurrentBuilds()
-        abortPreviousBuilds()
     }
 
     environment {


### PR DESCRIPTION
- changed agent label from 'docker-builder' to 'kub-suse-rancher-agent'.
- removed abortPreviousBuilds() option.