### PR TITLE
Remove Cleanup Cache stage from Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -102,13 +102,5 @@ pipeline {
 			}
 		}
 
-		stage('Cleanup Cache') {
-			steps {
-				container('buildah') {
-					sh 'buildah prune -a -f'
-				}
-			}
-		}
-
 	}
 }


### PR DESCRIPTION
- deleted the 'Cleanup Cache' stage in Jenkinsfile.
- removed unnecessary use of `buildah prune`.