### PR TITLE
Update OpenJDK image source in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:21-slim
+FROM docker.io/library/openjdk:21-slim
 
 ARG JAR_FILE=build/libs/app.jar
 COPY ${JAR_FILE} /app/app.jar


### PR DESCRIPTION
- changed base image to docker.io/library/openjdk:21-slim.