### PR TITLE
Update Docker base image and dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/openjdk:21-slim
+FROM docker.io/library/openjdk:21-jre-slim
 
 ARG JAR_FILE=build/libs/app.jar
 COPY ${JAR_FILE} /app/app.jar

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,9 @@
-extra["flywayCoreVersion"] = "11.3.3"
+extra["flywayCoreVersion"] = "11.4.1"
 extra["springdocVersion"] = "2.8.5"
 
 plugins {
     java
-    id("org.springframework.boot") version "3.4.3"
+    id("org.springframework.boot") version "3.4.4"
     id("io.spring.dependency-management") version "1.1.7"
 }
 


### PR DESCRIPTION
- changed Docker base image to `openjdk:21-jre-slim`.
- updated Flyway Core version to `11.4.1` in `build.gradle.kts`.
- bumped Spring Boot plugin version to `3.4.4` in `build.gradle.kts`.