### PR TITLE
Switch base image to eclipse-temurin:21-jre-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/openjdk:21-jre-slim
+FROM docker.io/library/eclipse-temurin:21-jre-alpine
 
 ARG JAR_FILE=build/libs/app.jar
 COPY ${JAR_FILE} /app/app.jar


### PR DESCRIPTION
- changed base image from openjdk:21-jre-slim to eclipse-temurin:21-jre-alpine.